### PR TITLE
Feature/16/setup colors and typography

### DIFF
--- a/code/config/webpack.config.js
+++ b/code/config/webpack.config.js
@@ -148,7 +148,16 @@ module.exports = {
   resolve: {
     extensions: [".js", ".jsx", ".ts", ".tsx", ".json"],
     alias: {
-      "@": path.join(__dirname, "..", "src")
+      "@": path.join(__dirname, "..", "src"),
+      "@design-system": path.join(
+        __dirname,
+        "..",
+        "src",
+        "styles",
+        "scss",
+        "foundation",
+        "_all.scss"
+      )
     }
   },
   devServer: {

--- a/code/src/components/app-button/AppButton.scss
+++ b/code/src/components/app-button/AppButton.scss
@@ -1,0 +1,40 @@
+@import "@design-system";
+
+// @TODO: It is just an example. Remove it or modify later
+.button__contained {
+  // Example of using variable from design system
+  background-color: var(--spa-button-bg-color, $purple);
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--spa-button-border-color, $purple);
+  color: var(--spa-button-color, $white);
+  // Example of using spacing
+  border-radius: spacing(2);
+  padding: spacing(2) spacing(3);
+
+  &:hover {
+    background-color: var(--spa-button-hover-color, transparent);
+    color: var(--spa-button-hover-color, $purple);
+  }
+
+  // Example of media query usage
+  @include breakpoint('md') {
+    border-radius: spacing(1);
+  }
+}
+
+.gray-100 {
+  background-color: $light;
+}
+
+.gray-300 {
+  background-color: $gray;
+}
+
+.gray-700 {
+  background-color: $ghost-alpha;
+}
+
+.gray-800 {
+  background-color: $dark-alpha;
+}

--- a/code/src/components/app-button/AppButton.tsx
+++ b/code/src/components/app-button/AppButton.tsx
@@ -1,0 +1,17 @@
+import Button, { ButtonProps } from "@mui/material/Button";
+import "@/components/app-button/AppButton.scss";
+
+type AppButtonProps = ButtonProps & {};
+
+// @TODO: It is just an example. Remove it or modify later
+export default function AppButton({
+  children,
+  className,
+  variant = "contained"
+}: AppButtonProps) {
+  return (
+    <Button className={`button button__${variant} ${className}`}>
+      {children}
+    </Button>
+  );
+}

--- a/code/src/components/app-typography/AppTypography.scss
+++ b/code/src/components/app-typography/AppTypography.scss
@@ -1,0 +1,50 @@
+@import "@design-system";
+
+.spa-typography {
+  font-family: $body-font-family;
+
+  &__h1 {
+    font-size: var(--spa-h1-font-size, $fs-h1);
+    font-weight: var(--spa-h1-font-weight, $fw-extra-bold);
+    font-weight: var(--spa-h1-text-transform, $tt-none);
+  }
+
+  &__h2 {
+    font-size: var(--spa-h2-font-size, $fs-h2);
+    font-weight: var(--spa-h2-font-weight, $fw-extra-bold);
+    font-weight: var(--spa-h2-text-transform, $tt-none);
+  }
+
+  &__h3 {
+    font-size: var(--spa-h3-font-size, $fs-h3);
+    font-weight: var(--spa-h3-font-weight, $fw-extra-bold);
+    font-weight: var(--spa-h3-text-transform, $tt-none);
+  }
+
+  &__body {
+    font-size: var(--spa-typography-body-font-size, $fs-base);
+  }
+
+  &__concept {
+    font-size: var(--spa-typography-concept-font-size, $fs-4xl);
+    font-weight: var(--spa-typography-concept-font-weight, $fw-extra-bold);
+    text-transform: var(--spa-typography-concept-text-transform, $tt-uppercase);
+  }
+
+  &__subtitle1 {
+    font-size: var(--spa-typography-subtitle1-font-size, $fs-xl);
+    font-weight: var(--spa-typography-subtitle1-font-weight, $fw-extra-bold);
+  }
+
+  &__subtitle2 {
+    font-size: var(--spa-typography-subtitle2-font-size, $fs-lg);
+  }
+
+  &__caption {
+    font-size: var(--spa-typography-caption-font-size, $fs-sm);
+  }
+
+  &__caption-small {
+    font-size: var(--spa-typography-caption-small-font-size, $fs-xs);
+  }
+}

--- a/code/src/components/app-typography/AppTypography.tsx
+++ b/code/src/components/app-typography/AppTypography.tsx
@@ -1,0 +1,69 @@
+import { ComponentProps, ReactNode } from "react";
+import { FormattedMessage } from "react-intl";
+import Typography, { TypographyProps } from "@mui/material/Typography";
+import "@/components/app-typography/AppTypography.scss";
+
+type HeadingVariant = "h1" | "h2" | "h3";
+type TextVariant =
+  | "body"
+  | "concept"
+  | "subtitle1"
+  | "subtitle2"
+  | "caption"
+  | "caption-small";
+type AppTypographyVariant = HeadingVariant | TextVariant;
+
+type AppTypographyProps = Omit<TypographyProps, "variant" | "children"> & {
+  variant?: AppTypographyVariant;
+} & (
+    | {
+        translationKey: string;
+        translationProps?: Omit<ComponentProps<typeof FormattedMessage>, "id">;
+        children?: never;
+      }
+    | {
+        translationKey?: never;
+        translationProps?: never;
+        children: ReactNode;
+      }
+  );
+
+function getDefaultComponentTag(variant: AppTypographyVariant) {
+  if (variant.startsWith("h")) {
+    return variant as HeadingVariant;
+  }
+
+  if (variant.startsWith("caption")) {
+    return "span";
+  }
+
+  return "p";
+}
+
+const AppTypography = ({
+  variant = "body",
+  className,
+  component,
+  children,
+  translationKey,
+  translationProps,
+  ...props
+}: AppTypographyProps) => {
+  const TypographyContent = translationKey ? (
+    <FormattedMessage id={translationKey} {...translationProps} />
+  ) : (
+    children
+  );
+
+  return (
+    <Typography
+      component={component ?? getDefaultComponentTag(variant)}
+      className={`spa-typography spa-typography__${variant} ${className}`}
+      {...props}
+    >
+      {TypographyContent}
+    </Typography>
+  );
+};
+
+export default AppTypography;

--- a/code/src/styles/scss/base/_root.scss
+++ b/code/src/styles/scss/base/_root.scss
@@ -1,3 +1,7 @@
 :root {
-  // @TODO: Add css variables
+  --spa-body-font-family: #{$lato};
+  --spa-body-font-size: #{$fs-base};
+  --spa-body-font-weight: #{$fw-regular};
+  
+  // @TODO: add more css variables
 }

--- a/code/src/styles/scss/foundation/_colors.scss
+++ b/code/src/styles/scss/foundation/_colors.scss
@@ -1,1 +1,1 @@
-// @TODO: Add colors
+// @TODO: Add more global colors

--- a/code/src/styles/scss/foundation/_functions.scss
+++ b/code/src/styles/scss/foundation/_functions.scss
@@ -1,0 +1,17 @@
+@function mapjoin($map, $delimiter) {
+  $result: "";
+
+  @each $key, $value in $map {
+    $result: $result + $delimiter + $value;
+  }
+
+  @return $result;
+}
+
+@function spacing($value: 1) {
+  @if $value != round($value) or $value <= 0 {
+    @error "#{$value} should be an integer in range from 1 to 10 inclusive";
+  }
+
+  @return $spacing-scale-factor * $value;
+}

--- a/code/src/styles/scss/foundation/_mixins.scss
+++ b/code/src/styles/scss/foundation/_mixins.scss
@@ -1,1 +1,24 @@
-// @TODO: Add mixins
+@import "variables";
+
+@mixin box($width, $height: $width) {
+  width: $width;
+  height: $height;
+}
+
+@mixin list-reset {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+@mixin breakpoint($size) {
+  @media (min-width: map-get($breakpoints, $size)) {
+    @content;
+  }
+}
+
+@mixin text-truncate($line-clamp: 1) {
+  display: -webkit-box;
+  -webkit-line-clamp: $line-clamp;
+  -webkit-box-orient: vertical;
+}

--- a/code/src/styles/scss/foundation/_typography.scss
+++ b/code/src/styles/scss/foundation/_typography.scss
@@ -1,1 +1,11 @@
-// @TODO: Add typography
+@import "variables";
+@import "functions";
+
+$font-weights: mapjoin($fw, ";");
+@import url("https://fonts.googleapis.com/css2?family=Lato:wght@#{$font-weights}&display=swap");
+
+$body-font-family: var(--spa-body-font-family, $lato) !default;
+$body-font-size: var(--spa-body-font-size, $fs-base) !default;
+$body-font-weight: var(--spa-body-font-weight, $fw-regular) !default;
+
+// // @TODO: add more global typography variables

--- a/code/src/styles/scss/foundation/_variables.scss
+++ b/code/src/styles/scss/foundation/_variables.scss
@@ -1,1 +1,106 @@
-// @TODO: Add variables
+/*=============================================
+ =                   COLORS                    =
+ =============================================*/
+
+/* Basic colors */
+
+$purple: #751fff;
+$purple-light: #d1b4ff;
+$red: #d72d2d;
+
+/* Additional colors */
+
+$white: #ffffff;
+$black: #000000;
+
+$light: #efefec;
+$gray: #575757;
+
+$ghost-alpha: rgba(0, 0, 0, 0.12);
+$dark-alpha: rgba(0, 0, 0, 0.7);
+
+/*=============================================
+=                TYPOGRAPHY                   =
+=============================================*/
+
+/* Font families */
+
+$lato: "Lato, sans-serif";
+
+/* Font weights */
+
+$fw-regular: 400;
+$fw-extra-bold: 700;
+
+$fw: (
+  regular: $fw-regular,
+  extra-bold: $fw-extra-bold
+);
+
+/* Font sizes (headings) */
+
+$fs-h1: 3.75rem; // 60px
+$fs-h2: 3.125rem; // 50px
+$fs-h3: 1.875rem; // 30px
+
+$fs-h: (
+  h1: $fs-h1,
+  h2: $fs-h2,
+  h3: $fs-h3
+);
+
+/* Font sizes (texts) */
+
+$fs-xs: 0.75rem; // 12px
+$fs-sm: 0.875rem; // 14px
+$fs-base: 1rem; // 16px
+$fs-lg: 1.25rem; // 20px
+$fs-xl: 1.375rem; // 22px
+$fs-4xl: 5.625rem; // 90px
+
+$fs: (
+  xs: $fs-xs,
+  sm: $fs-sm,
+  base: $fs-base,
+  lg: $fs-lg,
+  xl: $fs-xl,
+  4xl: $fs-4xl
+);
+
+/* Text transforms */
+
+$tt-none: none;
+$tt-uppercase: uppercase;
+
+$tt: (
+  none: $tt-none,
+  uppercase: $tt-uppercase
+);
+
+/*=====  End of TYPOGRAPHY  ======*/
+
+/*=============================================
+=                BREAKPOINTS                  =
+=============================================*/
+
+$screen-xs: 0;
+$screen-sm: 37.5rem; // 600px
+$screen-md: 56.25rem; // 900px
+$screen-lg: 75rem; // 1200px
+$screen-xl: 96rem; // 1536px
+
+$breakpoints: (
+  xs: $screen-xs,
+  sm: $screen-sm,
+  md: $screen-md,
+  lg: $screen-lg,
+  xl: $screen-xl
+);
+
+/*=============================================
+=                  SPACING                   =
+=============================================*/
+
+$spacing-scale-factor: 0.25rem; // 4px
+
+/*=====  End of BREAKPOINTS  ======*/

--- a/code/src/styles/scss/global.scss
+++ b/code/src/styles/scss/global.scss
@@ -2,3 +2,10 @@
 
 @import "base/reset";
 @import "base/root";
+
+body {
+  font-family: $body-font-family;
+  font-size: $body-font-size;
+  font-weight: $body-font-weight;
+  box-sizing: border-box;
+}


### PR DESCRIPTION
- Added variables inside `_variables.scss`
- Added scss functions inside `_functions.scss` to handling joining strings and to handle spacing
- Added mixins inside `_mixins.scss` to reuse repeated logic inside our scss
- Added font setup inside `_typography.scss`. Original font from our mockup is not free, so i used `Lato` instead
- Added base styles to body to `global.scss`, `_typography.scss` and `_root.scss`
- Added import alias to `webpack.config.js` to include all scss variables for your usage
- Added `AppTypography` component. It should be used to declare any typography in our project (including headings, captions etc)
- Added `AppButton` component as example of styling usage inside our future components

The more detailed explanation and code conventions will be discussed with our team and added to [docs](https://github.com/idx-academy/spa-orders/pull/32)

The general idea of our styling system is no create custom components (building blocks), that starts of prefix `App`, like `AppButton`, `AppTypography` etc. Then we use mui component inside as a base and add scss styles to it to customize it for our needs. Then we need to use `App`-prefixed component in our project and do not import it from mui directly. For building more complex components, like containers, layouts and pages we should use our wrappers around mui component. In that way we can easily migrate from mui to another ui package without huge refactorings.

**NOTE**: we should discuss with our team if we need to remove `ThemeProvider` from mui, because it will no have any effect on our styling system