### PR TITLE
Refactor test setup, add mock for FormattedMessage component

### DIFF
--- a/code/config/setup-tests.js
+++ b/code/config/setup-tests.js
@@ -1,65 +1,34 @@
 import React from "react";
-
 import crypto from "crypto";
-
 import failOnConsole from "jest-fail-on-console";
-
 import "@testing-library/jest-dom";
-
-const MOCK_TEST_LOCALE = 'en';
 
 global.React = React;
 
-failOnConsole({
-  shouldFailOnWarn: true,
-});
+failOnConsole({ shouldFailOnWarn: true });
 
-Object.defineProperty(global.self, 'crypto', {
+Object.defineProperty(global.self, "crypto", {
   value: {
-    getRandomValues: (arr) => crypto.randomBytes(arr.length),
-  },
+    getRandomValues: (arr) => crypto.randomBytes(arr.length)
+  }
 });
 
-jest.mock('react-redux', () => {
-  const actualReactRedux = jest.requireActual('react-redux');
-
-  return {
-    ...actualReactRedux,
-    useSelector: jest.fn(),
-  };
-});
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useHistory: () => ({
-    push: jest.fn(),
-    listen: jest.fn(),
-  }),
+jest.mock("react-redux", () => ({
+  ...jest.requireActual("react-redux"),
+  useSelector: jest.fn()
 }));
 
-const mockIntl = () => {
-  const applicationModuleI18n = require('@/shared/modules/application/i18n/en.json');
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useHistory: () => ({
+    push: jest.fn(),
+    listen: jest.fn()
+  })
+}));
 
-  return {
-    en: {
-      ...applicationModuleI18n,
-    },
-  };
-};
-
-const internalMessages = mockIntl();
-
-const formatMessage = (...args) => {
-  let foundStr = internalMessages[MOCK_TEST_LOCALE][args[0].id] || '';
-  for (let i = 1; i < args.length; i++) {
-    for (let key in args[i]) {
-      if (key !== 'id') {
-        foundStr = foundStr.replace(new RegExp('{' + key + '}', 'g'), args[i][key]);
-      }
-    }
-  }
-  return foundStr;
-};
-
+jest.mock("react-intl", () => ({
+  ...jest.requireActual("react-intl"),
+  FormattedMessage: jest.fn().mockImplementation(({ id }) => id)
+}));
 
 window.URL.createObjectURL = function () {};

--- a/code/src/components/app-typography/AppTypography.test.tsx
+++ b/code/src/components/app-typography/AppTypography.test.tsx
@@ -1,12 +1,7 @@
-import { FormattedMessage } from "react-intl";
 import { render, screen } from "@testing-library/react";
 import AppTypography, {
   AppTypographyVariant
 } from "@/components/app-typography/AppTypography";
-
-jest.mock("react-intl", () => ({
-  FormattedMessage: jest.fn()
-}));
 
 const renderAndCheckForTag = (
   expectedTagName: string,
@@ -35,8 +30,6 @@ describe("AppTypography", () => {
 
   test("should render translated text if translationKey is provided", () => {
     const translationKey = "translation.key";
-
-    (FormattedMessage as jest.Mock).mockReturnValueOnce(translationKey);
     render(<AppTypography translationKey={translationKey} />);
 
     const typography = screen.getByText(translationKey);

--- a/code/src/layouts/app-banner/AppBanner.test.tsx
+++ b/code/src/layouts/app-banner/AppBanner.test.tsx
@@ -1,17 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import AppBanner from "@/layouts/app-banner/AppBanner";
-import I18nProivider from "@/shared/i18n/I18nProvider";
 
 describe("AppBanner", () => {
   test("should render AppBanner component", () => {
-    render(
-      <I18nProivider>
-        <AppBanner />
-      </I18nProivider>
-    );
-    const headerText = screen.getByText(
-      /Incredible Prices on All Your Favorite Items/i
-    );
+    render(<AppBanner />);
+    const headerText = screen.getByText("appBanner.header");
     expect(headerText).toBeInTheDocument();
   });
 });

--- a/code/src/layouts/app-footer/AppFooter.test.jsx
+++ b/code/src/layouts/app-footer/AppFooter.test.jsx
@@ -1,15 +1,12 @@
 import { screen, render } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 import AppFooter from "@/layouts/app-footer/AppFooter";
-import I18nProivider from "@/shared/i18n/I18nProvider";
 
 describe("Test Footer component", () => {
   beforeEach(() => {
     render(
       <BrowserRouter>
-        <I18nProivider>
-          <AppFooter />
-        </I18nProivider>
+        <AppFooter />
       </BrowserRouter>
     );
   });

--- a/code/src/layouts/app-header/AppHeader.test.tsx
+++ b/code/src/layouts/app-header/AppHeader.test.tsx
@@ -1,12 +1,7 @@
 import { screen, render } from "@testing-library/react";
 import AppHeader from "@/layouts/app-header/AppHeader";
 
-jest.mock("@/layouts/app-header/components/header/Header", () => ({
-  __esModule: true,
-  default: () => "Header"
-}));
-
 test("renders Header and Categories components", () => {
   render(<AppHeader />);
-  expect(screen.getByText("Header")).toBeInTheDocument();
+  expect(screen.getByText("login.label")).toBeInTheDocument();
 });

--- a/code/src/layouts/app-header/components/header/Header.test.tsx
+++ b/code/src/layouts/app-header/components/header/Header.test.tsx
@@ -1,17 +1,10 @@
-import { FormattedMessage } from "react-intl";
 import { render, screen } from "@testing-library/react";
 import Header from "@/layouts/app-header/components/header/Header";
 
-jest.mock("react-intl", () => ({
-  FormattedMessage: jest.fn()
-}));
-
 describe("Header Component", () => {
   test("render the logo", () => {
-    (FormattedMessage as jest.Mock).mockReturnValueOnce("Logo");
-
     render(<Header />);
-
+    
     const logo = screen.getByAltText("Logo");
     expect(logo).toBeInTheDocument();
   });


### PR DESCRIPTION
Added mock for translations. Now it works like on Space2Study, `FormattedMessage` component returns same key as you pass to it to make testing simpler. Also I removed mocks and some providers, that are redundant