### PR TITLE
Added lazy-loading to pages

### DIFF
--- a/code/config/webpack.config.js
+++ b/code/config/webpack.config.js
@@ -94,7 +94,7 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: path.join(__dirname, "index.html")
     }),
-    new MiniCssExtractPlugin({ filename: "[name].css" }),
+    new MiniCssExtractPlugin({ filename: "[name].css", ignoreOrder: true }),
     new Dotenv({
       path: path.join(__dirname, "..", ".env.local")
     })
@@ -150,7 +150,7 @@ module.exports = {
       },
       {
         test: /\.(png|jpe?g|gif|svg|webp)$/i,
-        type: 'asset/resource',
+        type: "asset/resource",
         parser: {
           dataUrlCondition: {
             maxSize: 8192

--- a/code/src/components/app-skeleton/AppSkeleton.test.tsx
+++ b/code/src/components/app-skeleton/AppSkeleton.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from "@testing-library/react";
+import AppSkeleton from "@/components/app-skeleton/AppSkeleton";
+
+describe("Test AppSkeleton", () => {
+  test("Should render AppSkeleton", () => {
+    render(<AppSkeleton data-testid="app-skeleton" />);
+
+    const skeleton = screen.getByTestId("app-skeleton");
+
+    expect(skeleton).toBeInTheDocument();
+  });
+});

--- a/code/src/components/app-skeleton/AppSkeleton.tsx
+++ b/code/src/components/app-skeleton/AppSkeleton.tsx
@@ -1,0 +1,8 @@
+import Skeleton from "@mui/material/Skeleton";
+import { AppSkeletonProps } from "@/components/app-skeleton/AppSkeleton.types";
+
+const AppSkeleton = (props: AppSkeletonProps) => {
+  return <Skeleton {...props} />;
+};
+
+export default AppSkeleton;

--- a/code/src/components/app-skeleton/AppSkeleton.types.ts
+++ b/code/src/components/app-skeleton/AppSkeleton.types.ts
@@ -1,0 +1,3 @@
+import { SkeletonProps } from "@mui/material";
+
+export type AppSkeletonProps = SkeletonProps;

--- a/code/src/layouts/page-loading-fallback/PageLoadingFallback.scss
+++ b/code/src/layouts/page-loading-fallback/PageLoadingFallback.scss
@@ -1,5 +1,7 @@
 @import "@design-system";
 
+$header-height: 112px;
+
 .page-loading-fallback {
   height: calc($screen-height - $header-height - spacing(10));
   padding: spacing(5);

--- a/code/src/layouts/page-loading-fallback/PageLoadingFallback.scss
+++ b/code/src/layouts/page-loading-fallback/PageLoadingFallback.scss
@@ -1,0 +1,10 @@
+@import "@design-system";
+
+.page-loading-fallback {
+  height: calc($screen-height - $header-height - spacing(10));
+  padding: spacing(5);
+
+  &__skeleton {
+    height: 100%;
+  }
+}

--- a/code/src/layouts/page-loading-fallback/PageLoadingFallback.scss
+++ b/code/src/layouts/page-loading-fallback/PageLoadingFallback.scss
@@ -4,6 +4,10 @@
   height: calc($screen-height - $header-height - spacing(10));
   padding: spacing(5);
 
+  &__full-screen {
+    height: calc($screen-height - spacing(10));
+  }
+
   &__skeleton {
     height: 100%;
   }

--- a/code/src/layouts/page-loading-fallback/PageLoadingFallback.test.tsx
+++ b/code/src/layouts/page-loading-fallback/PageLoadingFallback.test.tsx
@@ -5,8 +5,34 @@ describe("Test PageLoadingFallback", () => {
   test("Should render loading fallback", () => {
     render(<PageLoadingFallback />);
 
-    const circleProgressElement = screen.getByTestId("page-loading-skeleton");
+    const fallbackContainerElement = screen.getByTestId(
+      "page-loading-fallback"
+    );
+    const skeletonElement = screen.getByTestId(
+      "page-loading-fallback-skeleton"
+    );
 
-    expect(circleProgressElement).toBeInTheDocument();
+    expect(fallbackContainerElement).toBeInTheDocument();
+    expect(skeletonElement).toBeInTheDocument();
+  });
+
+  test("Should have proper class when fullScreen is not passed", () => {
+    render(<PageLoadingFallback />);
+
+    const circleProgressElement = screen.getByTestId("page-loading-fallback");
+
+    expect(circleProgressElement).not.toHaveClass(
+      "page-loading-fallback__full-screen"
+    );
+  });
+
+  test("Should have proper class when fullScreen is passed", () => {
+    render(<PageLoadingFallback fullScreen />);
+
+    const circleProgressElement = screen.getByTestId("page-loading-fallback");
+
+    expect(circleProgressElement).toHaveClass(
+      "page-loading-fallback__full-screen"
+    );
   });
 });

--- a/code/src/layouts/page-loading-fallback/PageLoadingFallback.test.tsx
+++ b/code/src/layouts/page-loading-fallback/PageLoadingFallback.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from "@testing-library/react";
+import PageLoadingFallback from "@/layouts/page-loading-fallback/PageLoadingFallback";
+
+describe("Test PageLoadingFallback", () => {
+  test("Should render loading fallback", () => {
+    render(<PageLoadingFallback />);
+
+    const circleProgressElement = screen.getByTestId("page-loading-skeleton");
+
+    expect(circleProgressElement).toBeInTheDocument();
+  });
+});

--- a/code/src/layouts/page-loading-fallback/PageLoadingFallback.tsx
+++ b/code/src/layouts/page-loading-fallback/PageLoadingFallback.tsx
@@ -1,5 +1,5 @@
-import Skeleton from "@mui/material/Skeleton";
 import AppBox from "@/components/app-box/AppBox";
+import AppSkeleton from "@/components/app-skeleton/AppSkeleton";
 
 import cn from "@/utils/cn";
 
@@ -16,7 +16,7 @@ const PageLoadingFallback = ({ fullScreen }: PageLoadingFallbackProps) => {
       )}
       data-testid="page-loading-fallback"
     >
-      <Skeleton
+      <AppSkeleton
         data-testid="page-loading-fallback-skeleton"
         variant="rounded"
         className="page-loading-fallback__skeleton"

--- a/code/src/layouts/page-loading-fallback/PageLoadingFallback.tsx
+++ b/code/src/layouts/page-loading-fallback/PageLoadingFallback.tsx
@@ -1,12 +1,25 @@
 import Skeleton from "@mui/material/Skeleton";
 import AppBox from "@/components/app-box/AppBox";
 
+import cn from "@/utils/cn";
+
+import { PageLoadingFallbackProps } from "@/layouts/page-loading-fallback/PageLoadingFallback.types";
+
 import "@/layouts/page-loading-fallback/PageLoadingFallback.scss";
 
-const PageLoadingFallback = () => {
+const PageLoadingFallback = ({ fullScreen }: PageLoadingFallbackProps) => {
   return (
-    <AppBox className="page-loading-fallback">
-      <Skeleton variant="rounded" className="page-loading-fallback__skeleton" />
+    <AppBox
+      className={cn(
+        "page-loading-fallback",
+        fullScreen && "page-loading-fallback__full-screen"
+      )}
+    >
+      <Skeleton
+        data-testid="page-loading-skeleton"
+        variant="rounded"
+        className="page-loading-fallback__skeleton"
+      />
     </AppBox>
   );
 };

--- a/code/src/layouts/page-loading-fallback/PageLoadingFallback.tsx
+++ b/code/src/layouts/page-loading-fallback/PageLoadingFallback.tsx
@@ -14,9 +14,10 @@ const PageLoadingFallback = ({ fullScreen }: PageLoadingFallbackProps) => {
         "page-loading-fallback",
         fullScreen && "page-loading-fallback__full-screen"
       )}
+      data-testid="page-loading-fallback"
     >
       <Skeleton
-        data-testid="page-loading-skeleton"
+        data-testid="page-loading-fallback-skeleton"
         variant="rounded"
         className="page-loading-fallback__skeleton"
       />

--- a/code/src/layouts/page-loading-fallback/PageLoadingFallback.tsx
+++ b/code/src/layouts/page-loading-fallback/PageLoadingFallback.tsx
@@ -1,0 +1,14 @@
+import Skeleton from "@mui/material/Skeleton";
+import AppBox from "@/components/app-box/AppBox";
+
+import "@/layouts/page-loading-fallback/PageLoadingFallback.scss";
+
+const PageLoadingFallback = () => {
+  return (
+    <AppBox className="page-loading-fallback">
+      <Skeleton variant="rounded" className="page-loading-fallback__skeleton" />
+    </AppBox>
+  );
+};
+
+export default PageLoadingFallback;

--- a/code/src/layouts/page-loading-fallback/PageLoadingFallback.types.ts
+++ b/code/src/layouts/page-loading-fallback/PageLoadingFallback.types.ts
@@ -1,0 +1,3 @@
+export type PageLoadingFallbackProps = {
+  fullScreen?: boolean;
+};

--- a/code/src/layouts/root-layout/RootLayout.tsx
+++ b/code/src/layouts/root-layout/RootLayout.tsx
@@ -4,13 +4,16 @@ import Footer from "@/layouts/footer/Footer";
 import AppBox from "@/components/app-box/AppBox";
 
 import "@/layouts/root-layout/RootLayout.scss";
+import { Suspense } from "react";
 
 const RootLayout = () => {
   return (
     <AppBox className="root-layout">
       <Header />
       <AppBox className="root-layout__content">
-        <Outlet />
+        <Suspense>
+          <Outlet />
+        </Suspense>
       </AppBox>
       <Footer />
     </AppBox>

--- a/code/src/layouts/root-layout/RootLayout.tsx
+++ b/code/src/layouts/root-layout/RootLayout.tsx
@@ -1,17 +1,19 @@
+import { Suspense } from "react";
 import { Outlet } from "react-router-dom";
+
+import PageLoadingFallback from "@/layouts/page-loading-fallback/PageLoadingFallback";
 import Header from "@/layouts/header/Header";
 import Footer from "@/layouts/footer/Footer";
 import AppBox from "@/components/app-box/AppBox";
 
 import "@/layouts/root-layout/RootLayout.scss";
-import { Suspense } from "react";
 
 const RootLayout = () => {
   return (
     <AppBox className="root-layout">
       <Header />
       <AppBox className="root-layout__content">
-        <Suspense>
+        <Suspense fallback={<PageLoadingFallback />}>
           <Outlet />
         </Suspense>
       </AppBox>

--- a/code/src/main.tsx
+++ b/code/src/main.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { Provider } from "react-redux";
 import { createRoot } from "react-dom/client";
 import { StyledEngineProvider } from "@mui/material";
@@ -17,7 +18,9 @@ root.render(
     <StyledEngineProvider injectFirst>
       <I18nProivider>
         <ModalProvider>
-          <App />
+          <Suspense>
+            <App />
+          </Suspense>
         </ModalProvider>
       </I18nProivider>
     </StyledEngineProvider>

--- a/code/src/main.tsx
+++ b/code/src/main.tsx
@@ -19,7 +19,7 @@ root.render(
     <StyledEngineProvider injectFirst>
       <I18nProivider>
         <ModalProvider>
-          <Suspense fallback={<PageLoadingFallback />}>
+          <Suspense fallback={<PageLoadingFallback fullScreen />}>
             <App />
           </Suspense>
         </ModalProvider>

--- a/code/src/main.tsx
+++ b/code/src/main.tsx
@@ -4,6 +4,7 @@ import { createRoot } from "react-dom/client";
 import { StyledEngineProvider } from "@mui/material";
 
 import App from "@/App";
+import PageLoadingFallback from "@/layouts/page-loading-fallback/PageLoadingFallback";
 import I18nProivider from "@/context/I18nProvider";
 import { ModalProvider } from "@/context/ModalContext";
 import { store } from "@/store/store";
@@ -18,7 +19,7 @@ root.render(
     <StyledEngineProvider injectFirst>
       <I18nProivider>
         <ModalProvider>
-          <Suspense>
+          <Suspense fallback={<PageLoadingFallback />}>
             <App />
           </Suspense>
         </ModalProvider>

--- a/code/src/routes/routes.tsx
+++ b/code/src/routes/routes.tsx
@@ -1,13 +1,14 @@
 import { RouteObject } from "react-router-dom";
+import { lazy } from "react";
 
-// @TODO: Add lazy imports
 import RootLayout from "@/layouts/root-layout/RootLayout";
-import ErrorPage from "@/pages/error/ErrorPage";
-import NotFoundPage from "@/pages/not-found/NotFoundPage";
-import HomePage from "@/pages/home/HomePage";
-import ProductsPage from "@/pages/products/ProductsPage";
 
 import routePaths from "@/constants/routes";
+
+const ErrorPage = lazy(() => import("@/pages/error/ErrorPage"));
+const HomePage = lazy(() => import("@/pages/home/HomePage"));
+const ProductsPage = lazy(() => import("@/pages/products/ProductsPage"));
+const NotFoundPage = lazy(() => import("@/pages/not-found/NotFoundPage"));
 
 const routes: RouteObject[] = [
   {

--- a/code/src/styles/foundation/_functions.scss
+++ b/code/src/styles/foundation/_functions.scss
@@ -2,7 +2,7 @@
   $result: "";
 
   @each $key, $value in $map {
-    $result: $result + $delimiter + $value;
+    $result: if($result == "", $value, $result + $delimiter + $value);
   }
 
   @return $result;

--- a/code/src/styles/foundation/_variables.scss
+++ b/code/src/styles/foundation/_variables.scss
@@ -115,7 +115,6 @@ $spacing-scale-factor: 0.25rem;
 =============================================*/
 
 $screen-height: 100svh;
-$header-height: 112px;
 
 /*=====  End of SIZING  ======*/
 

--- a/code/src/styles/foundation/_variables.scss
+++ b/code/src/styles/foundation/_variables.scss
@@ -115,6 +115,7 @@ $spacing-scale-factor: 0.25rem;
 =============================================*/
 
 $screen-height: 100svh;
+$header-height: 112px;
 
 /*=====  End of SIZING  ======*/
 

--- a/code/tsconfig.json
+++ b/code/tsconfig.json
@@ -7,7 +7,7 @@
     },
     "baseUrl": ".",
     "target": "es6",
-    "module": "es2015",
+    "module": "ESNext",
     "moduleResolution": "node",
     "inlineSourceMap": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
- Changed ts module to `esnest`. Dynamic imports were introduced in `es2020` and setting esnext or `es2020` or just upper than `es2020` version is needed. I think `esnext` is a good choice because it includes newest features.
- Fixed scss `mapjoin` function. Previously it setted delimiter at the very beginning. Because of this, link for our fonts was not valid and request for them failed. It does not throw any error without `lazy`. But with `lazy`, there was `loading CSS chunk failed` error.
- Added `ignoreOrder` to configuration of `MiniCssExtractPlugin`. With `lazy loading`, `MiniCssExtractPlugin` throws an error, when import order does not equal usage order. As far as I investigated, it is done to properly rewrite `css` rules if the same selector is encountered (basically, if there is `a {rule}` and `a {rule}` again, the second will be applied). I don't think we need ordering error because everything works well without it and usually we do not rely on order of css rules. Besides, it would require us to sort imports according to their usage.
- Added two suspense. Suspense inside of `RootLayout` is for pages inside of layout, so when the page is changing, header and footer will not be suspended (still will be shown). Suspense inside of main is for other pages, which does not have layout, like error page. There are no fallbacks for now, maybe we will add them in future.
- Added lazy loading for pages in `router`.
- Added AppSkeleton and PageLoadingFallback, tests for it. I decided to use skeleton because we will have skeletons on product pages, and people with slow internet will see transition between page loading fallback and product items skeletons. In case of circle loader, it look not very well. Also, there are two variants of skeleton for page loading, one for pages with header and footer and the other one is full screen skeleton (with paddings)


Demonstration (skeleton is that grey thing that appears before content and quickly getting replaced by content)


https://github.com/idx-academy/spa-orders/assets/62070431/1bada516-2c6e-43ee-903e-a059ef240465


